### PR TITLE
updated rake task for Ruby 2.0 compatibility

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ Put hairtrigger in your Gemfile, or if you're not using bundler, you can
 Create lib/tasks/hair_trigger.rake with the following:
 
  $VERBOSE = nil
- Dir["#{Gem.searcher.find('hair_trigger').full_gem_path}/lib/tasks/*.rake"].each { |ext| load ext }
+ Dir["#{Gem::Specification.find_by_name('hairtrigger').full_gem_path}/lib/tasks/*.rake"].each { |ext| load ext }
 
 This will give you the db:generate_trigger_migration task, and will ensure
 that hairtrigger hooks into db:schema:dump.


### PR DESCRIPTION
Gem.searcher is deprecated, so I updated the rake task to use
Gem::Specification.find_all_by_name instead.
