### PR TITLE
Update dependency on ruby_parser to 3.4

### DIFF
--- a/hairtrigger.gemspec
+++ b/hairtrigger.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
- 
+
 require 'hair_trigger/version'
 
 Gem::Specification.new do |s|
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.files = %w(LICENSE.txt Rakefile README.rdoc) + Dir['lib/**/*.rb'] + Dir['lib/**/*.rake'] + Dir['spec/**/*.rb']
 
   s.add_dependency 'activerecord', '>= 2.3'
-  s.add_dependency 'ruby_parser', '~> 3.2.2'
+  s.add_dependency 'ruby_parser', '~> 3.4'
   s.add_dependency 'ruby2ruby', '~> 2.0.6'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.12.0'


### PR DESCRIPTION
Brakeman depends on a later version of ruby_parser, so it is not possible to use both Brakeman and hairtrigger in the same project. This updates the dependency to reflect that
