### PR TITLE
use debugger gem only for old ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem 'debugger'
+  gem 'debugger', platforms: [:ruby_18, :ruby_19]
 end
 
 group :test do


### PR DESCRIPTION
Gem debugger does not support ruby 2+ as description says [here](https://github.com/cldwalker/debugger). So it makes sense to limit than for specific platforms.