### PR TITLE
Elegant DEFINER sollution

### DIFF
--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -21,8 +21,7 @@ module HairTrigger
             triggers[name] = quote_table_name_in_trigger(definition) + ";\n"
           end
         when :mysql
-          select_rows("SHOW TRIGGERS").each do |(name, event, table, actions, timing, created, sql_mode, definer)|
-            definer = normalize_mysql_definer(definer)
+          select_rows("SHOW TRIGGERS").each do |(name, event, table, actions, timing, created, sql_mode)|
             next if options[:only] && !options[:only].include?(name)
             triggers[name.strip] = <<-SQL
 CREATE DEFINER = CURRENT_USER TRIGGER #{name} #{timing} #{event} ON `#{table}`

--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -11,17 +11,6 @@ module HairTrigger
     def drop_trigger(name, table, options = {})
       ::HairTrigger::Builder.new(name, options.merge(:execute => true, :drop => true, :table => table, :adapter => self)).all{}
     end
-
-    def normalize_mysql_definer(definer)
-      user, host = definer.split('@')
-      host = @config[:host] || 'localhost' if host == '%'
-      "'#{user}'@'#{host}'" # SHOW TRIGGERS doesn't quote them, but we need quotes for creating a trigger
-    end
-
-    def implicit_mysql_definer
-      "'#{@config[:username] || 'root'}'@'#{@config[:host] || 'localhost'}'"
-    end
-
     def triggers(options = {})
       triggers = {}
       name_clause = options[:only] ? "IN ('" + options[:only].join("', '") + "')" : nil
@@ -36,7 +25,7 @@ module HairTrigger
             definer = normalize_mysql_definer(definer)
             next if options[:only] && !options[:only].include?(name)
             triggers[name.strip] = <<-SQL
-CREATE #{definer != implicit_mysql_definer ? "DEFINER = #{definer} " : ""}TRIGGER #{name} #{timing} #{event} ON `#{table}`
+CREATE DEFINER = CURRENT_USER TRIGGER #{name} #{timing} #{event} ON `#{table}`
 FOR EACH ROW
 #{actions}
             SQL


### PR DESCRIPTION
When working with multiple databases in different environment you probably do not want to specify the user in the `db/schema.rb`. The `CURRENT_USER` should be right in all(most?) cases. Or am i missing something?