### PR TITLE
Ensure all() is not given any parameters when converted to ruby.

### DIFF
--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -310,6 +310,8 @@ module HairTrigger
             "for_each(#{options[:for_each].downcase.to_sym.inspect})"
           when :declare
             "declare(#{options[:declarations].inspect})"
+          when :all
+            'all'
           else
             "#{c}(#{options[c].inspect})"
         end


### PR DESCRIPTION
Currently it outputs `all(nil)` which throws an argument error since it doesn't take arguments.