### PR TITLE
Allow of() in trigger group for MySQL.

### DIFF
--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -140,7 +140,7 @@ module HairTrigger
           def #{method}(*args)
             @chained_calls << :#{method}
             if @triggers || @trigger_group
-              @errors << ["mysql doesn't support #{method} within a trigger group", :mysql] unless [:name, :where, :all].include?(:#{method})
+              @errors << ["mysql doesn't support #{method} within a trigger group", :mysql] unless [:name, :where, :all, :of].include?(:#{method})
             end
             set_#{method}(*args, &(block_given? ? Proc.new : nil))
           end


### PR DESCRIPTION
Allowing  `of()` from inside of a trigger group does not break anything in MySQL.  Tested on 5.6 and 5.7.