### PR TITLE
Add rails version to Migration

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -148,7 +148,7 @@ module HairTrigger
 # While you can edit this file, any changes you make to the definitions here
 # will be undone by the next auto-generated trigger migration.
 
-class #{migration_name} < ActiveRecord::Migration[#{[ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR].join("."}]
+class #{migration_name} < ActiveRecord::Migration[#{[ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR].join(".")}]
   def #{prefix}up
     #{(up_drop_triggers + up_create_triggers).map{ |t| t.to_ruby('    ') }.join("\n\n").lstrip}
   end

--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -148,7 +148,7 @@ module HairTrigger
 # While you can edit this file, any changes you make to the definitions here
 # will be undone by the next auto-generated trigger migration.
 
-class #{migration_name} < ActiveRecord::Migration
+class #{migration_name} < ActiveRecord::Migration[#{ActiveRecord::VERSION::STRING}]
   def #{prefix}up
     #{(up_drop_triggers + up_create_triggers).map{ |t| t.to_ruby('    ') }.join("\n\n").lstrip}
   end

--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -148,7 +148,7 @@ module HairTrigger
 # While you can edit this file, any changes you make to the definitions here
 # will be undone by the next auto-generated trigger migration.
 
-class #{migration_name} < ActiveRecord::Migration[#{ActiveRecord::VERSION::STRING}]
+class #{migration_name} < ActiveRecord::Migration[#{[ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR].join("."}]
   def #{prefix}up
     #{(up_drop_triggers + up_create_triggers).map{ |t| t.to_ruby('    ') }.join("\n\n").lstrip}
   end


### PR DESCRIPTION
Rails 5.1 requires Migrations to specify they version they're created for.