### PR TITLE
`ActiveRecord::Migrator.migrations` raises NoMethodError

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -41,9 +41,15 @@ module HairTrigger
     end
 
     def migrator
-      migrations = ActiveRecord::VERSION::STRING >= "4.0." ?
-        ActiveRecord::Migrator.migrations(migration_path) :
-        migration_path
+      version = ActiveRecord::VERSION::STRING
+      if version >= "5.2."
+        migrations = ActiveRecord::MigrationContext.new(migration_path).migrations
+      elsif version < "4.0."
+        migrations = migration_path
+      else # version >= "4.0."
+        migrations = ActiveRecord::Migrator.migrations(migration_path)
+      end
+
       ActiveRecord::Migrator.new(:up, migrations)
     end
 


### PR DESCRIPTION
Thank you for this great product. 

### Environment

- Ruby: 2.5.0
- Rails: 5.2.0

### About the error
I met the error shown below when run `rails db:migrate`

```
NoMethodError: undefined method `migrations' for ActiveRecord::Migrator:Class
/app/myapp/vendor/bundle/ruby/2.5.0/gems/hairtrigger-0.2.20/lib/hair_trigger.rb:45:in `migrator'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/hairtrigger-0.2.20/lib/hair_trigger.rb:65:in `current_migrations'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/hairtrigger-0.2.20/lib/hair_trigger/schema_dumper.rb:23:in `triggers'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/hairtrigger-0.2.20/lib/hair_trigger/schema_dumper.rb:7:in `trailer'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/schema_dumper.rb:39:in `dump'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/schema_dumper.rb:22:in `dump'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/railties/databases.rake:251:in `block (4 levels) in <top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/railties/databases.rake:250:in `open'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/railties/databases.rake:250:in `block (3 levels) in <top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/railties/databases.rake:68:in `block (2 levels) in <top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/railties/databases.rake:61:in `block (2 levels) in <top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/command.rb:48:in `invoke'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/commands.rb:18:in `<top (required)>'
/app/myapp/bin/rails:9:in `require'
/app/myapp/bin/rails:9:in `<top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/client/rails.rb:28:in `load'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/client/rails.rb:28:in `call'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/client/command.rb:7:in `call'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/client.rb:30:in `run'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/bin/spring:49:in `<top (required)>'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `load'
/app/myapp/vendor/bundle/ruby/2.5.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `<top (required)>'
/app/myapp/bin/spring:13:in `require'
/app/myapp/bin/spring:13:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:schema:dump
(See full trace by running task with --trace)
```

### Cause
This seems to result from [this commit](https://github.com/rails/rails/commit/a2827ec9811b5012e8e366011fd44c8eb53fc714)

`#migrations` moves from class methods to instance methods

Difference is: 
- from:
https://github.com/rails/rails/blob/v5.1.6/activerecord/lib/active_record/migration.rb#L1064-L1074

- to:
https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/migration.rb#L1086-L1097


Thanks for reading. 

### Note
With travisCI, my forked project's tests failed but I don't know how to fix them. It would be 
because of configuration; I would appreciate it if you could suggest how to fix when they also fail here.