### PR TITLE
Adjust adapter gem versions to required versions in Rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,28 +1,39 @@
 appraise "activerecord-3.2" do
   gem "activerecord", "~> 3.2.0"
-  gem "mysql", "~> 2.9.1"
-  gem "mysql2", "~> 0.3.11"
+  gem "mysql", "~> 2.8"
+  gem "mysql2", "~> 0.3.10"
+  gem 'pg', '~> 0.11'
+  gem "sqlite3", "~> 1.3.5"
 end
 
 appraise "activerecord-4.0" do
   gem "activerecord", "~> 4.0.0"
-  gem "mysql", "~> 2.9.1"
-  gem "mysql2", "~> 0.3.11"
+  gem "mysql", "~> 2.8"
+  gem "mysql2", "~> 0.3.10"
+  gem 'pg', '~> 0.11'
+  gem "sqlite3", "~> 1.3.6"
+
 end
 
 appraise "activerecord-4.2" do
   gem "activerecord", "~> 4.2.0"
-  gem "mysql", "~> 2.9.1"
-  gem "mysql2", "~> 0.3.11"
+  gem 'mysql', '~> 2.9'
+  gem 'mysql2', '>= 0.3.13', '< 0.5'
+  gem 'pg', '~> 0.15'
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise "activerecord-5.0" do
   gem "activerecord", "~> 5.0.0"
   gem "mysql2", "~> 0.4.4"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise "activerecord-edge" do
   gem "arel", github: "rails/arel"
   gem "activerecord", github: "rails/rails"
   gem "mysql2", "~> 0.3.11"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,4 @@ end
 group :test do
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 2.14.0'
-  gem 'pg', '>= 0.15.1'
-  gem 'sqlite3', '>= 1.3.7'
 end

--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -3,8 +3,10 @@
 source "http://rubygems.org"
 
 gem "activerecord", "~> 3.2.0"
-gem "mysql", "~> 2.9.1"
-gem "mysql2", "~> 0.3.11"
+gem "mysql", "~> 2.8"
+gem "mysql2", "~> 0.3.10"
+gem "pg", "~> 0.11"
+gem "sqlite3", "~> 1.3.5"
 
 group :development do
   gem "appraisal"
@@ -14,8 +16,6 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -3,8 +3,10 @@
 source "http://rubygems.org"
 
 gem "activerecord", "~> 4.0.0"
-gem "mysql", "~> 2.9.1"
-gem "mysql2", "~> 0.3.11"
+gem "mysql", "~> 2.8"
+gem "mysql2", "~> 0.3.10"
+gem "pg", "~> 0.11"
+gem "sqlite3", "~> 1.3.6"
 
 group :development do
   gem "appraisal"
@@ -14,8 +16,6 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -3,8 +3,10 @@
 source "http://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
-gem "mysql", "~> 2.9.1"
-gem "mysql2", "~> 0.3.11"
+gem "mysql", "~> 2.9"
+gem "mysql2", ">= 0.3.13", "< 0.5"
+gem "pg", "~> 0.15"
+gem "sqlite3", "~> 1.3.6"
 
 group :development do
   gem "appraisal"
@@ -14,8 +16,6 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -4,6 +4,8 @@ source "http://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 gem "mysql2", "~> 0.4.4"
+gem "pg", ">= 0.18", "< 2.0"
+gem "sqlite3", "~> 1.3.6"
 
 group :development do
   gem "appraisal"
@@ -13,8 +15,6 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_5.1.gemfile
+++ b/gemfiles/activerecord_5.1.gemfile
@@ -13,8 +13,8 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -2,9 +2,11 @@
 
 source "http://rubygems.org"
 
-gem "arel", :github => "rails/arel"
-gem "activerecord", :github => "rails/rails"
+gem "arel", github: "rails/arel"
+gem "activerecord", github: "rails/rails"
 gem "mysql2", "~> 0.3.11"
+gem "pg", ">= 0.18", "< 2.0"
+gem "sqlite3", "~> 1.3.6"
 
 group :development do
   gem "appraisal"
@@ -14,8 +16,6 @@ end
 group :test do
   gem "rake", "~> 10.0"
   gem "rspec", "~> 2.14.0"
-  gem "pg", ">= 0.15.1"
-  gem "sqlite3", ">= 1.3.7"
 end
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
It was impossible to run tests on Travis CI due too loose requirements on gem versions. Bundler was loading version too new for specific Rails version.

I have copied required versions from `active_record/connection_adapters/*` for each adapter*.

----
(*) There was an issue with mysql2 0.4.3 and Rails 5.x so I kept `~> 0.4.4` version constraint.