### PR TITLE
Make builder work with frozen strings

### DIFF
--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -34,6 +34,13 @@ describe "builder" do
       builder.on(:foos).after(:update){ "FOO " }.generate.
         grep(/FOO;/).size.should eql(1)
     end
+
+    it "should work with frozen strings" do
+      @adapter = MockAdapter.new("mysql")
+      lambda {
+        builder.on(:foos).after(:update){ "FOO".freeze }.generate
+      }.should_not raise_error
+    end
   end
 
   context "comparison" do


### PR DESCRIPTION
Hey @jenseng,

I stumbled upon the error when defining triggers in file with `frozen_string_literals: true` comment. It turned out the builder is modifying SQL trigger body in place. I fixed it by using immutable modifications while ensuring semicolon presence.

WDYT?