### PR TITLE
Ensure hair_trigger ActiveRecord settings run after app load

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -226,7 +226,9 @@ end
   end
 end
 
-ActiveRecord::Base.send :extend, HairTrigger::Base
-ActiveRecord::Migration.send :include, HairTrigger::Migrator
-ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval { include HairTrigger::Adapter }
-ActiveRecord::SchemaDumper.class_eval { include HairTrigger::SchemaDumper }
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send :extend, HairTrigger::Base
+  ActiveRecord::Migration.send :include, HairTrigger::Migrator
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval { include HairTrigger::Adapter }
+  ActiveRecord::SchemaDumper.class_eval { include HairTrigger::SchemaDumper }
+end


### PR DESCRIPTION
This PR addresses the problem of ActiveRecord::Base being called prior to a Rails apps own initializers being loaded. It manifested specifically in an inability to set `Rails.application.config.active_record.belongs_to_required_by_default = true` during our Rails 5 upgrade.

The fix is basically cribbing this fix right here: https://github.com/ankane/ahoy/issues/213 when the issue was seen in another gem.