### PR TITLE
[FIX] Fix schema:dump monkey patched task to handle multiple database configurations

### DIFF
--- a/lib/tasks/hair_trigger.rake
+++ b/lib/tasks/hair_trigger.rake
@@ -12,11 +12,22 @@ namespace :db do
     desc "Create a db/schema.rb file that can be portably used against any DB supported by AR"
     task :dump => :environment do
       require 'active_record/schema_dumper'
-      filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
-      ActiveRecord::SchemaDumper.previous_schema = File.exist?(filename) ? File.read(filename) : nil
-      File.open(filename, "w") do |file|
-        ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+
+      databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
+
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        filename = name == 'primary' ? "#{Rails.root}/db/schema.rb" : "#{Rails.root}/db/#{name}_schema.rb"
+
+        ActiveRecord::SchemaDumper.previous_schema = File.exist?(filename) ? File.read(filename) : nil
+
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
+        connection_pool = ActiveRecord::Base.establish_connection(db_config)
+
+        File.open(filename, "w") do |file|
+          ActiveRecord::SchemaDumper.dump(connection_pool.connection, file)
+        end
       end
+
       Rake::Task["db:schema:dump"].reenable
     end
   end


### PR DESCRIPTION
[FIX] Fix schema:dump monkey patched task to handle multiple database configurations

Here is the issue raised in original gem: https://github.com/jenseng/hair_trigger/issues/95

