### PR TITLE
Add Ruby 3 to CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,15 +46,14 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - env:
           DB_CONFIG: github-actions
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           MYSQLPORT: ${{ job.services.mysql.ports[3306] }}
         run: |
           sudo apt-get -yqq install libpq-dev libmysqlclient-dev
-          gem install bundler
-          bundle install
           bundle exec rspec

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        ruby: ['2.5', '2.7']
+        ruby: ['2.5', '2.7', '3.0']
         gemfile: [ 'activerecord_5.0',
                    'activerecord_5.1',
                    'activerecord_5.2',
@@ -40,6 +40,10 @@ jobs:
         ]
         exclude:
           - { ruby: '2.5', gemfile: 'activerecord_7.0' }
+          - { ruby: '3.0', gemfile: 'activerecord_5.0' }
+          - { ruby: '3.0', gemfile: 'activerecord_5.1' }
+          - { ruby: '3.0', gemfile: 'activerecord_5.2' }
+
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ CONFIGS = YAML.load(ERB.new(File.read(File.expand_path(File.dirname(__FILE__) + 
 ADAPTERS = [:mysql2, :postgresql, :sqlite3]
 ADAPTERS.unshift :mysql if ActiveRecord::VERSION::STRING < "5"
 
-def each_adapter
+def each_adapter(&block)
   require 'active_record/connection_adapters/postgresql_adapter'
   require 'active_record/connection_adapters/mysql_adapter' if ADAPTERS.include? :mysql
   require 'active_record/connection_adapters/mysql2_adapter'
@@ -20,7 +20,7 @@ def each_adapter
   ADAPTERS.each do |adapter_name|
     context "under #{adapter_name}" do
       let(:adapter) { adapter_name }
-      instance_eval &Proc.new
+      instance_eval &Proc.new(&block)
     end
   end
 end


### PR DESCRIPTION
Also start using ruby/setup-ruby instead of actions/setup-ruby which is deprecated. This allows us to test with 3.0 but also  allows us to cache bundler between runs.
