### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        ruby: ['2.5', '2.7', '3.0']
+        ruby: ['2.5', '2.7', '3.0', '3.1']
         gemfile: [ 'activerecord_5.0',
                    'activerecord_5.1',
                    'activerecord_5.2',
@@ -43,7 +43,10 @@ jobs:
           - { ruby: '3.0', gemfile: 'activerecord_5.0' }
           - { ruby: '3.0', gemfile: 'activerecord_5.1' }
           - { ruby: '3.0', gemfile: 'activerecord_5.2' }
-
+          - { ruby: '3.1', gemfile: 'activerecord_5.0' }
+          - { ruby: '3.1', gemfile: 'activerecord_5.1' }
+          - { ruby: '3.1', gemfile: 'activerecord_5.2' }
+          - { ruby: '3.1', gemfile: 'activerecord_6.0' }
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -13,8 +13,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_5.1.gemfile
+++ b/gemfiles/activerecord_5.1.gemfile
@@ -13,8 +13,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_5.2.gemfile
+++ b/gemfiles/activerecord_5.2.gemfile
@@ -13,8 +13,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -13,8 +13,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -13,8 +13,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -9,12 +9,11 @@ gem "sqlite3", "~> 1.4.0"
 
 group :development do
   gem "appraisal"
-  gem "byebug"
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -14,8 +14,8 @@ group :development do
 end
 
 group :test do
-  gem "rake", "~> 12.3.3"
-  gem "rspec", "~> 2.14.0"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.11.0"
 end
 
 gemspec :path => "../"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,14 @@ require 'hair_trigger'
 require 'yaml'
 require 'shellwords'
 
-CONFIGS = YAML.load(ERB.new(File.read(File.expand_path(File.dirname(__FILE__) + '/../database.yml'))).result(binding))[ENV["DB_CONFIG"] || "test"]
+database_yml_contents = ERB.new(File.read(File.expand_path(File.dirname(__FILE__) + '/../database.yml'))).result(binding)
+
+CONFIGS = if Psych::VERSION >= '4.0'
+  YAML.safe_load(database_yml_contents, aliases: true)[ENV["DB_CONFIG"] || "test"]
+else
+  YAML.safe_load(database_yml_contents, [], [], true)[ENV["DB_CONFIG"] || "test"]
+end
+
 ADAPTERS = [:mysql2, :postgresql, :sqlite3]
 ADAPTERS.unshift :mysql if ActiveRecord::VERSION::STRING < "5"
 


### PR DESCRIPTION
In addition to the necessary changes to the `workflow.yml` - added `3.1` and excluding unsupported ActiveRecord/Ruby combinations, the following changes were made:

1. Updated gemfiles to modern versions of rake and rspec - this was necessary to get specs running.  There are some deprecation warnings, but everything runs green
2. Use YAML safe_load with an aliases true argument - As Psych 4.0+ now calls `safe_load` for `load`, we make this call explicit and add the necessary aliases argument for it to pass.  