### PR TITLE
Update previous_schema regex to account for Rails 7

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -82,7 +82,7 @@ module HairTrigger
       if previous_schema = (options.has_key?(:previous_schema) ? options[:previous_schema] : File.exist?(schema_rb_path) && File.read(schema_rb_path))
         base_triggers = MigrationReader.get_triggers(previous_schema, options)
         unless base_triggers.empty?
-          version = (previous_schema =~ /ActiveRecord::Schema\.define\(.*?(\d+)\)/) && $1.to_i
+          version = (previous_schema =~ /ActiveRecord::Schema(\[\d\.\d\])?\.define\(version\: (.*)\)/) && $2.to_i
           migrations.unshift [OpenStruct.new({:version => version}), base_triggers]
         end
       end


### PR DESCRIPTION
Rails 7's schema.rb looks similar to `ActiveRecord::Schema[7.0].define(version: 2022_01_26_205052)` which breaks how the regex works, causing `assert HairTrigger::migrations_current?` to fail. This PR fixes that.