### PR TITLE
Fix schema.rb with ActiveRecord::Schema[7.0].define

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -82,7 +82,7 @@ module HairTrigger
       if previous_schema = (options.has_key?(:previous_schema) ? options[:previous_schema] : File.exist?(schema_rb_path) && File.read(schema_rb_path))
         base_triggers = MigrationReader.get_triggers(previous_schema, options)
         unless base_triggers.empty?
-          version = (previous_schema =~ /ActiveRecord::Schema\.define\(.*?(\d+)\)/) && $1.to_i
+          version = (previous_schema =~ /ActiveRecord::Schema(\[\d\.\d\])?\.define\(.*?(\d+)\)/) && $1.to_i
           migrations.unshift [OpenStruct.new({:version => version}), base_triggers]
         end
       end


### PR DESCRIPTION
```
ActiveRecord::Schema[7.0].define(version: 2022_05_17_144011) do
```


Without Fix:
```
[1] pry(main)> HairTrigger::migrations_current?
  ActiveRecord::SchemaMigration Pluck (0.5ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
ArgumentError: comparison of NilClass with 20220517144011 failed
from /usr/local/rvm/gems/ruby-3.1.2/gems/hairtrigger-0.2.25/lib/hair_trigger.rb:90:in `sort_by'
```

With Fix:
```
[1] pry(main)> HairTrigger::migrations_current?
  ActiveRecord::SchemaMigration Pluck (0.5ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
=> true
```