### PR TITLE
[FIX]  fix migration issue for multiple database support(issue #95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.x
 
+- fix `rails db:migrate` issue for multiple databases ([PR #1](https://github.com/heyjobs/hair_trigger/pull/1))
+
 ### 1.0.0
 
 - rails 7 bugfix ([PR 104](https://github.com/jenseng/hair_trigger/pull/104) and [PR 106](https://github.com/jenseng/hair_trigger/pull/106))

--- a/lib/tasks/hair_trigger.rake
+++ b/lib/tasks/hair_trigger.rake
@@ -12,12 +12,43 @@ namespace :db do
     desc "Create a db/schema.rb file that can be portably used against any DB supported by AR"
     task :dump => :environment do
       require 'active_record/schema_dumper'
-      filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
-      ActiveRecord::SchemaDumper.previous_schema = File.exist?(filename) ? File.read(filename) : nil
-      File.open(filename, "w") do |file|
-        ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+
+      databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
+
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
+        connection_pool = ActiveRecord::Base.establish_connection(db_config)
+
+        filename = dump_filename(db_config.name)
+        ActiveRecord::SchemaDumper.previous_schema = File.exist?(filename) ? File.read(filename) : nil
+
+        File.open(filename, "w") do |file|
+          ActiveRecord::SchemaDumper.dump(connection_pool.connection, file)
+        end
       end
+
       Rake::Task["db:schema:dump"].reenable
+    end
+
+    def schema_file_type(format)
+      case format
+        when :ruby
+          "schema.rb"
+        when :sql
+          "structure.sql"
+      end
+    end
+
+    # code adopted from activerecord/lib/active_record/tasks/database_tasks.rb#L441
+    def dump_filename(db_config_name)
+      format = ActiveRecord::Base.schema_format
+      filename = if ActiveRecord::Base.configurations.primary?(db_config_name)
+                   schema_file_type(format)
+                 else
+                   "#{db_config_name}_#{schema_file_type(format)}"
+                 end
+
+      ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
     end
   end
 end


### PR DESCRIPTION
Fix following issue(#95). This is the rebase from pull request #98.

**Background:**
We are trying to set up multiple databases with our **Rails 7** application. Due to this gem, we are facing an issue.

When we are running **rails db:migrate**

it is overwriting the primary **db/schema.rb** file with secondary schema file **db/marketing_sync_board_schema.rb**. After the migration command run both are the same. 

They are not causing any database label changes.

Also if we are using database-specific command it is working fine. 
`rails db:migrate`
`rails db:migrate:marketing_sync_board`

sample database.yml with multi database setup.
<pre>
default: &default
  adapter: postgresql
  encoding: unicode
  host: localhost
  database: multi_db_test_app_development
  username: admin
  password:
  pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>

marketing_sync_board_default: &marketing_sync_board_default
  <<: *default
  host: localhost
  username: admin
  password:
  database: marketing_sync_board_development
  migrations_paths: db/marketing_sync_board_migrate

development:
  primary:
    <<: *default
    database: multi_db_test_app_secondary_development
  marketing_sync_board:
    <<: *marketing_sync_board_default
</pre>