### PR TITLE
Skip schema.rb when schema_format is set to :sql

### DIFF
--- a/lib/tasks/hair_trigger.rake
+++ b/lib/tasks/hair_trigger.rake
@@ -11,6 +11,8 @@ namespace :db do
   namespace :schema do
     desc "Create a db/schema.rb file that can be portably used against any DB supported by AR"
     task :dump => :environment do
+      next unless ActiveRecord::Base.schema_format == :ruby
+
       require 'active_record/schema_dumper'
       filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
       ActiveRecord::SchemaDumper.previous_schema = File.exist?(filename) ? File.read(filename) : nil


### PR DESCRIPTION
Fix for https://github.com/jenseng/hair_trigger/issues/93.
Behavior stays the same as it was for Rails 5 and above.
As it's said in the issue, we don't need to generate a `schema.rb` when we don't have the setting `schema_format = :ruby`.