### PR TITLE
Feat: support Postgres schema config setting

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -13,7 +13,7 @@ module HairTrigger
   autoload :MigrationReader, 'hair_trigger/migration_reader'
 
   class << self
-    attr_writer :model_path, :schema_rb_path, :migration_path
+    attr_writer :model_path, :schema_rb_path, :migration_path, :pg_schema
 
     def current_triggers
       # see what the models say there should be
@@ -221,6 +221,10 @@ end
 
     def migration_path
       @migration_path ||= 'db/migrate'
+    end
+
+    def pg_schema
+      @pg_schema ||= 'public'
     end
 
     def adapter_name_for(adapter)

--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -48,7 +48,7 @@ FOR EACH ROW
               SELECT tgfoid
               FROM pg_trigger
               WHERE NOT tgisinternal AND tgconstrrelid = 0 AND tgrelid IN (
-                SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+                SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '#{HairTrigger.pg_schema}')
               )
             )
           SQL
@@ -57,9 +57,9 @@ FOR EACH ROW
             SELECT tgname::varchar, pg_get_triggerdef(oid, true)
             FROM pg_trigger
             WHERE NOT tgisinternal AND tgconstrrelid = 0 AND tgrelid IN (
-              SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+              SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '#{HairTrigger.pg_schema}')
             )
-            
+
             #{name_clause ? " AND tgname::varchar " + name_clause : ""}
             UNION
             SELECT proname || '()', pg_get_functiondef(oid)


### PR DESCRIPTION
We stumbled upon a app, that uses another Postgres schema by default. In that case ``rails db:schema:dump`` will not include the triggers by HairTrigger.

This PR makes the schema configurable and will keep `public` as default.