### PR TITLE
Support trilogy as mysql adapter

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,6 @@
 appraise "activerecord-6.0" do
   gem "activerecord", "~> 6.0.0"
+  gem "activerecord-trilogy-adapter", "~> 3.0.0"
   gem "mysql2", "~> 0.4.10"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4.0"
@@ -7,6 +8,7 @@ end
 
 appraise "activerecord-6.1" do
   gem "activerecord", "~> 6.1.0"
+  gem "activerecord-trilogy-adapter", "~> 3.0.0"
   gem "mysql2", "~> 0.5"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4.0"
@@ -14,6 +16,7 @@ end
 
 appraise "activerecord-7.0" do
   gem "activerecord", "~> 7.0.0"
+  gem "activerecord-trilogy-adapter", "~> 3.0.0"
   gem "mysql2", "~> 0.5"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.0.x
+## 1.1.x
+
+## 1.1.0
+
+- Add support for trilogy adapter ([PR 115](https://github.com/jenseng/hair_trigger/pulls)
 
 ### 1.0.0
 

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.0.0"
+gem "activerecord-trilogy-adapter"
 gem "mysql2", "~> 0.4.10"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4.0"

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.0"
+gem "activerecord-trilogy-adapter"
 gem "mysql2", "~> 0.5"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4.0"

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.0"
+gem "activerecord-trilogy-adapter", "~> 3.0.0"
 gem "mysql2", "~> 0.5"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4.0"

--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -31,7 +31,7 @@ module HairTrigger
           select_rows("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' #{name_clause ? " AND name " + name_clause : ""}").each do |(name, definition)|
             triggers[name] = quote_table_name_in_trigger(definition) + ";\n"
           end
-        when :mysql
+        when :mysql, :trilogy
           select_rows("SHOW TRIGGERS").each do |(name, event, table, actions, timing, created, sql_mode, definer)|
             definer = normalize_mysql_definer(definer)
             next if options[:only] && !options[:only].include?(name)
@@ -59,7 +59,7 @@ FOR EACH ROW
             WHERE NOT tgisinternal AND tgconstrrelid = 0 AND tgrelid IN (
               SELECT oid FROM pg_class WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
             )
-            
+
             #{name_clause ? " AND tgname::varchar " + name_clause : ""}
             UNION
             SELECT proname || '()', pg_get_functiondef(oid)

--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -162,7 +162,7 @@ module HairTrigger
     chainable_methods :name, :on, :for_each, :before, :after, :where, :security, :timing, :events, :all, :nowrap, :of, :declare
 
     def create_grouped_trigger?
-      adapter_name == :mysql
+      adapter_name == :mysql || adapter_name == :trilogy
     end
 
     def prepare!
@@ -224,7 +224,7 @@ module HairTrigger
         [case adapter_name
           when :sqlite
             generate_trigger_sqlite
-          when :mysql
+          when :mysql, :trilogy
             generate_trigger_mysql
           when :postgresql, :postgis
             generate_trigger_postgresql
@@ -407,7 +407,7 @@ module HairTrigger
 
     def generate_drop_trigger
       case adapter_name
-        when :sqlite, :mysql
+        when :sqlite, :mysql, :trilogy
           "DROP TRIGGER IF EXISTS #{prepared_name};\n"
         when :postgresql, :postgis
           "DROP TRIGGER IF EXISTS #{prepared_name} ON #{adapter.quote_table_name(options[:table])};\nDROP FUNCTION IF EXISTS #{adapter.quote_table_name(prepared_name)}();\n"

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -55,6 +55,11 @@ describe "adapter" do
       it_behaves_like "mysql"
     end if ADAPTERS.include? :mysql2
 
+    context "trilogy" do
+      let(:adapter) { :trilogy }
+      it_behaves_like "mysql"
+    end if ADAPTERS.include? :trilogy
+
     context "postgresql" do
       let(:adapter) { :postgresql }
 


### PR DESCRIPTION
Add support for trilogy adapter 

https://github.com/trilogy-libraries/trilogy
https://github.com/trilogy-libraries/activerecord-trilogy-adapter

Trilogy adapter is now supported as a native mysql adapter in Rails 7.1