### PR TITLE
Add support for mysql2rgeo DB adapter

### DIFF
--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -31,7 +31,7 @@ module HairTrigger
           select_rows("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' #{name_clause ? " AND name " + name_clause : ""}").each do |(name, definition)|
             triggers[name] = quote_table_name_in_trigger(definition) + ";\n"
           end
-        when :mysql, :trilogy
+        when :mysql, :trilogy, :mysql2rgeo
           select_rows("SHOW TRIGGERS").each do |(name, event, table, actions, timing, created, sql_mode, definer)|
             definer = normalize_mysql_definer(definer)
             next if options[:only] && !options[:only].include?(name)

--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -162,7 +162,7 @@ module HairTrigger
     chainable_methods :name, :on, :for_each, :before, :after, :where, :security, :timing, :events, :all, :nowrap, :of, :declare
 
     def create_grouped_trigger?
-      adapter_name == :mysql || adapter_name == :trilogy
+      adapter_name == :mysql || adapter_name == :trilogy || adapter_name == :mysql2rgeo
     end
 
     def prepare!
@@ -224,7 +224,7 @@ module HairTrigger
         [case adapter_name
           when :sqlite
             generate_trigger_sqlite
-          when :mysql, :trilogy
+          when :mysql, :trilogy, :mysql2rgeo
             generate_trigger_mysql
           when :postgresql, :postgis
             generate_trigger_postgresql
@@ -407,7 +407,7 @@ module HairTrigger
 
     def generate_drop_trigger
       case adapter_name
-        when :sqlite, :mysql, :trilogy
+        when :sqlite, :mysql, :trilogy, :mysql2rgeo
           "DROP TRIGGER IF EXISTS #{prepared_name};\n"
         when :postgresql, :postgis
           "DROP TRIGGER IF EXISTS #{prepared_name} ON #{adapter.quote_table_name(options[:table])};\nDROP FUNCTION IF EXISTS #{adapter.quote_table_name(prepared_name)}();\n"

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -60,6 +60,11 @@ describe "adapter" do
       it_behaves_like "mysql"
     end if ADAPTERS.include? :trilogy
 
+    context "mysql2rgeo" do
+      let(:adapter) { :mysql2rgeo }
+      it_behaves_like "mysql"
+    end if ADAPTERS.include? :mysql2rgeo
+
     context "postgresql" do
       let(:adapter) { :postgresql }
 


### PR DESCRIPTION
Hi, 
I have been using hair_trigger for some time, and now I need to start using mysql2rgeo DB adapter to handle some spatial data.
[mysql2rgeo](https://github.com/stadia/activerecord-mysql2rgeo-adapter) extends basic myslq2 adapter with spatial functionalities.

As I would like to continue using hair_trigger I posted da PR to add support for mysql2rgeo adapter.
I hope you will consider this addition and let me know if anything needs to be modified.

All the best
Jan
