### PR TITLE
Appaisals: really test against ActiveRecord 7.1.x

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -16,7 +16,7 @@ appraise "activerecord-7.0" do
 end
 
 appraise "activerecord-7.1" do
-  gem "activerecord", "~> 7.0.0"
+  gem "activerecord", "~> 7.1.0"
   gem "mysql2", "~> 0.5"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4.0"


### PR DESCRIPTION
This looks like a simple copy/paste issue, with this change the gem should be tested against the correct `activerecord` version.