### PR TITLE
Add ostruct gem explicitly

### DIFF
--- a/hairtrigger.gemspec
+++ b/hairtrigger.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 6.0', '< 8'
   s.add_dependency 'ruby_parser', '~> 3.10'
   s.add_dependency 'ruby2ruby', '~> 2.4'
+  s.add_dependency 'ostruct'
 end


### PR DESCRIPTION
Removes the following warning from Ruby 3.3.5:
```
/hair_trigger/lib/hair_trigger.rb:1: warning: .asdf/installs/ruby/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```