### PR TITLE
Add configuration class for custom adapters

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -12,11 +12,24 @@ module HairTrigger
   MYSQL_ADAPTERS = %i[mysql mysql2rgeo trilogy]
   SQLITE_ADAPTERS = %i[sqlite litedb]
 
+  autoload :Configuration, 'hair_trigger/configuration'
   autoload :Builder, 'hair_trigger/builder'
   autoload :MigrationReader, 'hair_trigger/migration_reader'
 
   class << self
     attr_writer :model_path, :schema_rb_path, :migration_path, :pg_schema
+
+    def configure
+      yield hair_trigger_config
+    end
+
+    def hair_trigger_config
+      @hair_trigger_config ||= Configuration.new(
+        postgresql_adapters: POSTGRESQL_ADAPTERS,
+        mysql_adapters:      MYSQL_ADAPTERS,
+        sqlite_adapters:     SQLITE_ADAPTERS
+      )
+    end
 
     def current_triggers
       # see what the models say there should be

--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -27,11 +27,11 @@ module HairTrigger
       name_clause = options[:only] ? "IN ('" + options[:only].join("', '") + "')" : nil
       adapter_name = HairTrigger.adapter_name_for(self)
       case adapter_name
-        when *HairTrigger::SQLITE_ADAPTERS
+        when *HairTrigger.hair_trigger_config.sqlite_adapters
           select_rows("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' #{name_clause ? " AND name " + name_clause : ""}").each do |(name, definition)|
             triggers[name] = quote_table_name_in_trigger(definition) + ";\n"
           end
-        when *HairTrigger::MYSQL_ADAPTERS
+        when *HairTrigger.hair_trigger_config.mysql_adapters
           select_rows("SHOW TRIGGERS").each do |(name, event, table, actions, timing, created, sql_mode, definer)|
             definer = normalize_mysql_definer(definer)
             next if options[:only] && !options[:only].include?(name)
@@ -41,7 +41,7 @@ FOR EACH ROW
 #{actions}
             SQL
           end
-        when *POSTGRESQL_ADAPTERS
+        when *HairTrigger.hair_trigger_config.postgresql_adapters
           function_conditions = "(SELECT typname FROM pg_type WHERE oid = prorettype) = 'trigger'"
           function_conditions << <<-SQL unless options[:simple_check]
             AND oid IN (

--- a/lib/hair_trigger/configuration.rb
+++ b/lib/hair_trigger/configuration.rb
@@ -1,0 +1,11 @@
+module HairTrigger
+  class Configuration
+    attr_accessor :postgresql_adapters, :mysql_adapters, :sql_adapters
+
+    def initialize(postgresql_adapters: [], mysql_adapters: [], sqlite_adapters: [])
+      @postgresql_adapters = postgresql_adapters
+      @mysql_adapters      = mysql_adapters
+      @sqlite_adapters     = sqlite_adapters
+    end
+  end
+end

--- a/lib/hair_trigger/schema_dumper.rb
+++ b/lib/hair_trigger/schema_dumper.rb
@@ -74,7 +74,7 @@ module HairTrigger
     def normalize_trigger(name, definition, type)
       @adapter_name = @connection.adapter_name.downcase.to_sym
 
-      return definition unless HairTrigger::POSTGRESQL_ADAPTERS.include?(@adapter_name)
+      return definition unless HairTrigger.hair_trigger_config.postgresql_adapters.include?(@adapter_name)
       # because postgres does not preserve the original CREATE TRIGGER/
       # FUNCTION statements, its decompiled reconstruction will not match
       # ours. we work around it by creating our generated trigger/function,


### PR DESCRIPTION
The list of supported adapters is hardcoded, which makes it difficult to use this gem on custom adapters.

We use `postgresql_proxy` from `active_record_proxy_adapters`, for instance. Currently, we need to monkey patch the gem and hot swap the constant `HairTrigger::POSTGRESQL_ADAPTERS`  when the application boots to make it work with the proxy adapter.

Although it works, it's not ideal.

I've added a new configuration class whose values will default to the current ones (`%i[mysql2 trilogy]` for `mysql_adapters`, `%i[postgresql postgis]` for `postgresql_adapters` , and `%i[sqlite litedb]` for `sqlite_adapters`), but allow the user to add custom adapters for each.

I don't expect any breaking changes here as the values fall back to the existing constants, but please double check. Thanks!