### PR TITLE
Remove ostruct dependency

### DIFF
--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'fileutils'
 require 'active_record'
 require 'hair_trigger/base'
@@ -18,6 +17,8 @@ module HairTrigger
 
   class << self
     attr_writer :model_path, :schema_rb_path, :migration_path, :pg_schema
+
+    Migration = Struct.new(:name, :version, keyword_init: true)
 
     def configure
       yield hair_trigger_config
@@ -99,7 +100,7 @@ module HairTrigger
         base_triggers = MigrationReader.get_triggers(previous_schema, options)
         unless base_triggers.empty?
           version = (previous_schema =~ /ActiveRecord::Schema(\[\d\.\d\])?\.define\(version\: (.*)\)/) && $2.to_i
-          migrations.unshift [OpenStruct.new({:version => version}), base_triggers]
+          migrations.unshift [Migration.new({:version => version}), base_triggers]
         end
       end
 


### PR DESCRIPTION
Remove `ostruct` dependency since it is deprecated from Ruby's standard library and needs to be included explicitly as it will no longer be available in Ruby 3.5. 

https://github.com/jenseng/hair_trigger/issues/129