### PR TITLE
Prepare for Ruby 3.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
           --health-retries 3
     strategy:
       matrix:
-        ruby: ["3.2", "3.3"]
+        ruby: ["3.2", "3.3", "3.4"]
         gemfile: ["activerecord_6.1", "activerecord_7.0", "activerecord_7.1", "activerecord_7.2", "activerecord_8.0"]
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/lib/hair_trigger.rb
+++ b/lib/hair_trigger.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'fileutils'
 require 'active_record'
 require 'hair_trigger/base'
@@ -15,6 +14,8 @@ module HairTrigger
   autoload :Configuration, 'hair_trigger/configuration'
   autoload :Builder, 'hair_trigger/builder'
   autoload :MigrationReader, 'hair_trigger/migration_reader'
+
+  Migration = Struct.new(:name, :version, keyword_init: true)
 
   class << self
     attr_writer :model_path, :schema_rb_path, :migration_path, :pg_schema
@@ -99,7 +100,7 @@ module HairTrigger
         base_triggers = MigrationReader.get_triggers(previous_schema, options)
         unless base_triggers.empty?
           version = (previous_schema =~ /ActiveRecord::Schema(\[\d\.\d\])?\.define\(version\: (.*)\)/) && $2.to_i
-          migrations.unshift [OpenStruct.new({:version => version}), base_triggers]
+          migrations.unshift [Migration.new({:version => version}), base_triggers]
         end
       end
 

--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -571,7 +571,7 @@ BEGIN
 
       def compatibility
         @compatibility ||= begin
-          if HairTrigger::VERSION <= "0.1.3"
+          if Gem::Version.new(HairTrigger::VERSION) <= Gem::Version.new("0.1.3")
             0 # initial releases
           else
             1 # postgres RETURN bugfix

--- a/lib/hair_trigger/version.rb
+++ b/lib/hair_trigger/version.rb
@@ -1,7 +1,5 @@
+# frozen_string_literal: true
+
 module HairTrigger
   VERSION = "1.3.1"
-
-  def VERSION.<=>(other)
-    split(/\./).map(&:to_i) <=> other.split(/\./).map(&:to_i)
-  end
 end


### PR DESCRIPTION
This pull request is fixing some 3.4 deprecations by:

- Remove monkey patching the version (and replaced it with regular `Gem::Version` comparison)
- Add ruby 3.4 to the github matrix
- Replace `OpenStruct` with `Struct` (as `OpenStruct` will be an own gem in ruby 3.5)