### PR TITLE
Ensure frozen string literals work

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,4 +51,5 @@ jobs:
           DB_CONFIG: github-actions
           PGPORT: ${{ job.services.postgres.ports[5432] }}
           MYSQLPORT: ${{ job.services.mysql.ports[3306] }}
+          RUBYOPT: --enable-frozen-string-literal
         run: bundle exec rspec

--- a/lib/hair_trigger/adapter.rb
+++ b/lib/hair_trigger/adapter.rb
@@ -42,7 +42,7 @@ FOR EACH ROW
             SQL
           end
         when *HairTrigger.hair_trigger_config.postgresql_adapters
-          function_conditions = "(SELECT typname FROM pg_type WHERE oid = prorettype) = 'trigger'"
+          function_conditions = +"(SELECT typname FROM pg_type WHERE oid = prorettype) = 'trigger'"
           function_conditions << <<-SQL unless options[:simple_check]
             AND oid IN (
               SELECT tgfoid

--- a/lib/hair_trigger/builder.rb
+++ b/lib/hair_trigger/builder.rb
@@ -254,7 +254,7 @@ module HairTrigger
         str << ")"
       else
         if @trigger_group
-          str = "t." + chained_calls_to_ruby + " do\n"
+          str = "t.#{chained_calls_to_ruby} do\n"
           str << actions_to_ruby("#{indent}  ") + "\n"
           str << "#{indent}end"
         else
@@ -468,7 +468,7 @@ END;
       raise GenerationError, "of can only be used in conjunction with nowrap on postgres 9.1 and greater" if options[:nowrap] && options[:of] && db_version < 90100
       raise GenerationError, "referencing can only be used on postgres 10.0 and greater" if options[:referencing] && db_version < 100000
 
-      sql = ''
+      sql = +""
 
       if options[:nowrap]
         trigger_action = raw_actions
@@ -513,7 +513,7 @@ FOR EACH #{options[:for_each]}#{prepared_where && db_version >= 90000 ? " WHEN (
 
     def generate_trigger_mysql
       security = options[:security] if options[:security] && options[:security] != :definer
-      sql = <<-SQL
+      sql = +<<-SQL
 CREATE #{security ? "DEFINER = #{security} " : ""}TRIGGER #{prepared_name} #{options[:timing]} #{options[:events].first} ON `#{options[:table]}`
 FOR EACH #{options[:for_each]}
 BEGIN
@@ -542,6 +542,7 @@ BEGIN
     end
 
     def normalize(text, level = 0)
+      text = text.dup
       indent = level * self.class.tab_spacing
       text.gsub!(/\t/, ' ' * self.class.tab_spacing)
       existing = text.split(/\n/).map{ |line| line.sub(/[^ ].*/, '').size }.min
@@ -571,7 +572,7 @@ BEGIN
 
       def compatibility
         @compatibility ||= begin
-          if HairTrigger::VERSION <= "0.1.3"
+          if Gem::Version.new(HairTrigger::VERSION) <= Gem::Version.new("0.1.3")
             0 # initial releases
           else
             1 # postgres RETURN bugfix

--- a/lib/hair_trigger/schema_dumper.rb
+++ b/lib/hair_trigger/schema_dumper.rb
@@ -87,11 +87,11 @@ module HairTrigger
         @connection.execute(definition.sub(name, test_name))
         # now add them back
         if type == :function
-          test_name << '()'
-          name << '()'
+          test_name = "#{test_name}()"
+          name = "#{name}()"
         end
         definition = @connection.triggers(:only => [test_name], :simple_check => true).values.first
-        definition.sub!(test_name, name)
+        definition = definition.sub(test_name, name)
         raise ActiveRecord::Rollback
       end
       definition

--- a/lib/hair_trigger/version.rb
+++ b/lib/hair_trigger/version.rb
@@ -1,7 +1,3 @@
 module HairTrigger
   VERSION = "1.3.1"
-
-  def VERSION.<=>(other)
-    split(/\./).map(&:to_i) <=> other.split(/\./).map(&:to_i)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,7 @@ shared_context "hairtrigger utils" do
     config = CONFIGS[adapter.to_s].merge({:adapter => adapter.to_s})
     case adapter
       when :mysql2
-        command = "mysql"
+        command = +"mysql"
         command << " -u #{Shellwords.escape(config['username'])}" if config['username']
         command << " -P #{Shellwords.escape(config['port'])}" if config['port']
         command << " -p#{Shellwords.escape(config['password'])}" if config['password']
@@ -66,7 +66,7 @@ shared_context "hairtrigger utils" do
         ret = `echo "drop database if exists #{Shellwords.escape(config['database'])}; create database #{Shellwords.escape(config['database'])} collate utf8_general_ci;" | #{command} 2>&1`
         raise "error creating database: #{ret}" unless $?.exitstatus == 0
       when :postgresql
-        command = "%s"
+        command = +"%s"
         command = "PGPASSWORD=#{Shellwords.escape(config['password'])} #{command}" if config['password']
         command << " -U #{Shellwords.escape(config['username'])}" if config['username']
         command << " -p #{Shellwords.escape(config['port'])}" if config['port']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ shared_context "hairtrigger utils" do
   end
 
   def initialize_db
-    if ActiveRecord::VERSION::STRING > "7.0."
+    if ActiveRecord.gem_version > Gem::Version.new("7.0.0")
       ActiveRecord::Base.connection_handler.clear_all_connections!
     else
       ActiveRecord::Base.clear_all_connections!
@@ -85,7 +85,7 @@ shared_context "hairtrigger utils" do
 
   def migrate_db
     ActiveRecord::Migration.verbose = false
-    if ActiveRecord::VERSION::STRING > "7.0."
+    if ActiveRecord.gem_version > Gem::Version.new("7.0.0")
       ActiveRecord::MigrationContext.new(HairTrigger.migration_path).migrate
     else
       ActiveRecord::MigrationContext.new(HairTrigger.migration_path, ActiveRecord::SchemaMigration).migrate


### PR DESCRIPTION
`hair_trigger` shows a lot of deprecation warnings because it modifies the `VERSION` string to introduce a `<=>` method, and that constant holds a string literal.

To ensure this gem works properly when frozen strings are enabled, this PR uses the `--enable-frozen-string-literal` Ruby option when running the tests. That made some specs fail, making it necessary to change some string literals to use `+` to make them mutable.